### PR TITLE
Ssl connection

### DIFF
--- a/src/app/player.service.ts
+++ b/src/app/player.service.ts
@@ -118,7 +118,7 @@ export class PlayerService {
     this.getConfig().subscribe(config => {
 
       let protocol = "http";
-      if(config.useHttps == null || config.useHttps === true) {
+      if(config.useHttps === true) {
           protocol = "https";
       }
 

--- a/src/app/player.service.ts
+++ b/src/app/player.service.ts
@@ -116,7 +116,13 @@ export class PlayerService {
 
   private sendRequest(url: string) {
     this.getConfig().subscribe(config => {
-      const baseUrl = 'http://' + config.server + ':' + config.port + '/' + config.rooms[0] + '/';
+
+      let protocol = "http";
+      if(config.useHttps == null || config.useHttps === true) {
+          protocol = "https";
+      }
+
+      const baseUrl = protocol + '://' + config.server + ':' + config.port + '/' + config.rooms[0] + '/';
       this.http.get(baseUrl + url).subscribe();
     });
   }

--- a/src/app/sonos-api.ts
+++ b/src/app/sonos-api.ts
@@ -1,6 +1,7 @@
 export interface SonosApiConfig {
     server: string;
     port: string;
+    useHttps?: boolean;
     rooms: string[];
     tts?: {
         enabled?: boolean;


### PR DESCRIPTION
Adds the option to support https connections to node-sonos-http-api-server
Adds the option to choose if the connection to node-sonos-http-api-server is http or https